### PR TITLE
idempotent delete

### DIFF
--- a/sprox/iprovider.py
+++ b/sprox/iprovider.py
@@ -155,7 +155,7 @@ class IProvider:
         raise NotImplementedError
 
     def delete(self, entity, params):
-        """Delete an entry of typeentity which matches the params."""
+        """Delete an entry of type entity which matches the params."""
         raise NotImplementedError
 
     def query(self,entity,limit=None,offset=None,limit_fields=None,order_by=None,desc=False):

--- a/sprox/mg/provider.py
+++ b/sprox/mg/provider.py
@@ -406,7 +406,10 @@ class MingProvider(IProvider):
     def delete(self, entity, params):
         """Delete an entry of typeentity which matches the params."""
         obj = self.get_obj(entity, params)
-        obj.delete()
+        try:
+            obj.delete()
+        except AttributeError:
+            pass  # It is idempotent to delete something that does not exists
         return obj
 
     def _modify_params_for_related_searches(self, entity, params, view_names=None, substrings=()):

--- a/sprox/mg/provider.py
+++ b/sprox/mg/provider.py
@@ -406,10 +406,8 @@ class MingProvider(IProvider):
     def delete(self, entity, params):
         """Delete an entry of typeentity which matches the params."""
         obj = self.get_obj(entity, params)
-        try:
+        if obj is not None:
             obj.delete()
-        except AttributeError:
-            pass  # It is idempotent to delete something that does not exists
         return obj
 
     def _modify_params_for_related_searches(self, entity, params, view_names=None, substrings=()):

--- a/sprox/sa/provider.py
+++ b/sprox/sa/provider.py
@@ -647,10 +647,8 @@ class SAORMProvider(IProvider):
     # This is hard to test because of some kind of rollback issue in the test framework
     def delete(self, entity, params):  # pragma: no cover
         obj = self._get_obj(entity, params)
-        try:
+        if obj is not None:
             self.session.delete(obj)
-        except UnmappedInstanceError:
-            pass
         return obj
 
     def get_field_widget_args(self, entity, field_name, field):

--- a/sprox/sa/provider.py
+++ b/sprox/sa/provider.py
@@ -647,7 +647,10 @@ class SAORMProvider(IProvider):
     # This is hard to test because of some kind of rollback issue in the test framework
     def delete(self, entity, params):  # pragma: no cover
         obj = self._get_obj(entity, params)
-        self.session.delete(obj)
+        try:
+            self.session.delete(obj)
+        except UnmappedInstanceError:
+            pass
         return obj
 
     def get_field_widget_args(self, entity, field_name, field):

--- a/tests/test_mgormprovider.py
+++ b/tests/test_mgormprovider.py
@@ -1063,7 +1063,12 @@ class TestMGORMProvider(SproxTest):
         assert val == [{'value': 1234}], val
 
     def test_delete(self):
-        user = self.provider.delete(User, params={'_id': self.asdf_user_id})
+        self.provider.delete(User, params={'_id': self.asdf_user_id})
+        session.flush()
+        users = User.query.find().all()
+        assert len(users) == 0
+        # Tests twice for idempotence
+        self.provider.delete(User, params={'_id': self.asdf_user_id})
         session.flush()
         users = User.query.find().all()
         assert len(users) == 0

--- a/tests/test_saormprovider.py
+++ b/tests/test_saormprovider.py
@@ -374,12 +374,18 @@ class TestSAORMProvider(SproxTest):
         eq_(user['user_name'], 'asdf')
 
     def test_delete(self):
-        #causes some kind of persistence error in SA 0.7 (rollback not working)
+        # causes some kind of persistence error in SA 0.7 (rollback not working)
+        # everything seems ok with SA 1.1.14, maybe it has been fixed
 
-        if sqlalchemy.__version__ > '0.6.6':
+        sa_version = sqlalchemy.__version__
+        if sa_version > '0.6.6' and sa_version < '1.1.14':
             raise SkipTest
 
-        user = self.provider.delete(User, params={'user_id':1})
+        self.provider.delete(User, params={'user_id': 1})
+        users = self.session.query(User).all()
+        assert len(users) == 0
+        # Tests twice for idempotence
+        self.provider.delete(User, params={'user_id': 1})
         users = self.session.query(User).all()
         assert len(users) == 0
 


### PR DESCRIPTION
deletion of non existing instances doesn't throw exceptions anymore