### PR TITLE
Align with recent SQLAlchemy change

### DIFF
--- a/sprox/sa/support.py
+++ b/sprox/sa/support.py
@@ -32,5 +32,7 @@ def resolve_entity(entity):
         entity = entity()
     if _class_resolver is not None and isinstance(entity, _class_resolver):
         entity = entity()
+    elif hasattr(entity, '__self__'):
+        entity = entity()
     return entity
 

--- a/sprox/sa/support.py
+++ b/sprox/sa/support.py
@@ -28,11 +28,10 @@ except ImportError:  # pragma: no cover
 
 
 def resolve_entity(entity):
-    if inspect.isfunction(entity):
+    if inspect.isfunction(entity) or inspect.ismethod(entity):
         entity = entity()
     if _class_resolver is not None and isinstance(entity, _class_resolver):
         entity = entity()
-    elif hasattr(entity, '__self__'):
-        entity = entity()
     return entity
+
 


### PR DESCRIPTION
SQLAlchemy has changed such that the value stored in the argument property of a RelationshipProperty is a bound method. This results in errors of the following variety when invoking get_value on an EditFormFiller, for example:

   sqlalchemy.exc.ArgumentError: Class object expected, got '<bound method _class_resolver._resolve_name of <sqlalchemy.ext.declarative.clsregistry._class_resolver object at 0x7f57a53c2a30>>'.

The change that caused this is here: https://github.com/sqlalchemy/sqlalchemy/commit/17e31604ae13ebd58b148a4319cfed09e5448ee2. The argument property is now set via resolve_name instead of resolve_arg.

An approach to fixing this is to modify the resolve_entity method to add an elif to check for a bound method.